### PR TITLE
Use fs.createWriteStream instead of many await writeFile promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.7
+
+- Use fs.createWriteStream instead of fs/promises for writing outputs
+
 # v1.0.6
 
 - Fix writing ix and ixx files to await the filehandle.writeFile call


### PR DESCRIPTION
This is a possible way to avoid doing millions of await writeFile calls when writing a large file, by instead using streaming write. It has a trick for awaiting "backpressure" if the code is not keeping up with the fast writing but it should be correct even without that https://nodesource.com/blog/understanding-streams-in-nodejs/
