### PR TITLE
External sorting to reduce memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^16.0.1",
+    "@types/tmp": "^0.2.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.3.5"
   },
@@ -24,5 +25,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "external-sorting": "^1.2.0",
+    "tmp": "^0.2.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { promisify } from "util";
 import { finished } from "stream";
+import { Readable } from "stream";
+import { once } from "events";
 import fs from "fs";
 import readline from "readline";
-import { Readable } from "stream";
-
-import { once } from "events";
+import tmp from "tmp";
+import esort from "external-sorting";
 
 const streamFinished = promisify(finished); // (A)
 
@@ -66,42 +67,27 @@ function initCharTables() {
 
 type Hash = any;
 
-function indexWords(
-  wordHash: Hash,
-  itemId: string,
-  words: string[],
-  itemIdHash: Hash
-) {
-  itemIdHash[itemId] = true;
-  words.forEach((word, wordIx) => {
-    if (!wordHash[word]) {
-      wordHash[word] = [];
-    }
-    wordHash[word].push({ itemId, wordIx: wordIx + 1 });
-  });
-}
+async function makeIxStream(fileStream: Readable, outIxFilename: string) {
+  initCharTables();
 
-type WordHash = {
-  [key: string]: { itemId: number; wordIx: number }[];
-};
-
-async function writeIndexHash(wordHash: WordHash, fileName: string) {
-  const out = fs.createWriteStream(fileName);
+  const tmpobj = tmp.fileSync();
+  const out = fs.createWriteStream(tmpobj.name);
   try {
-    for (const [name, val] of Object.entries(wordHash).sort((a, b) =>
-      a[0].localeCompare(b[0])
-    )) {
-      const res = out.write(
-        `${name} ${val
-          .sort((a, b) => a.wordIx - b.wordIx)
-          .map((pos) => `${pos.itemId},${pos.wordIx}`)
-          .join(" ")}\n`
-      );
+    const rl = readline.createInterface({
+      input: fileStream,
+    });
 
-      // Handle backpressure
-      // ref https://nodesource.com/blog/understanding-streams-in-nodejs/
-      if (!res) {
-        await once(out, "drain");
+    for await (const line of rl) {
+      const [id, ...words] = line.split(/\s+/);
+      for (let i = 0; i < words.length; i++) {
+        const word = words[i];
+        const res = out.write(`${word.toLowerCase()} ${id}\n`);
+
+        // Handle backpressure
+        // ref https://nodesource.com/blog/understanding-streams-in-nodejs/
+        if (!res) {
+          await once(out, "drain");
+        }
       }
     }
   } finally {
@@ -109,29 +95,52 @@ async function writeIndexHash(wordHash: WordHash, fileName: string) {
 
     await streamFinished(out);
   }
-}
 
-async function makeIxStream(fileStream: Readable, outIndex: string) {
-  initCharTables();
+  const tmpobj2 = tmp.fileSync();
+  const outSort = fs.createWriteStream(tmpobj2.name);
+  await esort({
+    input: fs.createReadStream(tmpobj.name),
+    output: outSort,
+    tempDir: __dirname,
+    maxHeap: 10000,
+  }).asc();
 
-  const rl = readline.createInterface({
-    input: fileStream,
-  });
+  // superstitious streamFinished on the file that esort outputs
+  await streamFinished(outSort);
 
-  const wordHash = {};
-  const itemIdHash = {};
+  const outIx = fs.createWriteStream(outIxFilename);
+  try {
+    const readFinalStream = fs.createReadStream(tmpobj2.name);
+    const rl2 = readline.createInterface({
+      input: readFinalStream,
+    });
 
-  for await (const line of rl) {
-    const [id, ...text] = line.split(/\s+/);
-    indexWords(
-      wordHash,
-      id,
-      text.map((s) => s.toLowerCase()),
-      itemIdHash
-    );
+    let current;
+    let buff = [];
+    for await (const line of rl2) {
+      const [id, data] = line.split(" ");
+      if (current !== id) {
+        current = id;
+        if (buff.length) {
+          const res = outIx.write(
+            `${current} ${buff.map((elt, idx) => `${elt},${idx}`).join(" ")}\n`
+          );
+          buff = [];
+
+          // Handle backpressure
+          // ref https://nodesource.com/blog/understanding-streams-in-nodejs/
+          if (!res) {
+            await once(outIx, "drain");
+          }
+        }
+      }
+      buff.push(data);
+    }
+  } finally {
+    outIx.end();
+
+    await streamFinished(outIx);
   }
-
-  await writeIndexHash(wordHash, outIndex);
 }
 
 async function makeIx(inFile: string, outIndex: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.1.tgz#70cedfda26af7a2ca073fdcc9beb2fff4aa693f8"
   integrity sha512-hBOx4SUlEPKwRi6PrXuTGw1z6lz0fjsibcWCM378YxsSu/6+C30L6CR49zIBKHiwNWCYIcOLjg4OHKZaFeLAug==
 
+"@types/tmp@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.1.tgz#83ecf4ec22a8c218c71db25f316619fe5b986011"
+  integrity sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -24,6 +29,18 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+external-sorting@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/external-sorting/-/external-sorting-1.2.0.tgz#e2f492be8caf171c0f5fcd5831b565bcd2117a46"
+  integrity sha512-VJ61/dKifQd2wmEPi3SeMnYTjCbeysPcAxfGpQzIbC2mEdgaNBhCWw+lM4Km8sEzYkOToxLT7XV80hdM1UykoQ==
+  dependencies:
+    fast-sort "^2.0.1"
+
+fast-sort@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fast-sort/-/fast-sort-2.2.0.tgz#20903763531fbcbb41c9df5ab1bf5f2cefc8476a"
+  integrity sha512-W7zqnn2zsYoQA87FKmYtgOsbJohOrh7XrtZrCVHN5XZKqTBTv5UG+rSS3+iWbg/nepRQUOu+wnas8BwtK8kiCg==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -74,12 +91,19 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 typescript@^4.3.5:
   version "4.3.5"


### PR DESCRIPTION
In trying to make this package more scalable, I ran into some hard limits

The Object e.g. {} only allows ~8.3M keys (2^23) and then produces 100% CPU hanging on adding additional elements
Converting to Map allows 16.7M keys (2^24) but then fails with a crazy error message https://bugs.chromium.org/p/v8/issues/detail?id=11852

This takes a new route and performs an external sort on the dataset.

The basic idea is:


Take data in the form

base64([blob stuff here]) key words to index

Then write to a new file in tmp

key base64([blob stuff here]) 
words base64([blob stuff here]) 
to base64([blob stuff here]) 
index base64([blob stuff here]) 


Then use external-sorting npm package to sort this to a new tmp file

index base64([blob stuff here]) 
key base64([blob stuff here]) 
to base64([blob stuff here]) 
words base64([blob stuff here]) 


Then turn this into a new .ix file and .ixx

The progress bar technically can wait a long time at "nearly finished" while it performs a large sort but we could think about this as a separate issue. This PR, as implemented, should make memory usage much reduced



