### PR TITLE
Restore external-sorting module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Restore external-sorting pure-JS sort
+
 # v2.1.1
 
 - More accurately determine end of stream

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@types/command-exists": "^1.2.1",
     "@types/jest": "^29.2.4",
     "@types/node": "^20.5.9",
     "@types/split2": "^4.2.0",
@@ -21,7 +22,6 @@
     "jest": "^29.3.1",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.1",
-    "tmp": "^0.2.1",
     "ts-jest": "^29.0.3",
     "typescript": "^5.2.2"
   },
@@ -42,6 +42,9 @@
     "access": "public"
   },
   "dependencies": {
-    "split2": "^4.1.0"
+    "command-exists": "^1.2.9",
+    "external-sorting": "^1.3.1",
+    "split2": "^4.1.0",
+    "tmp": "^0.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,6 +683,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/command-exists@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/command-exists/-/command-exists-1.2.1.tgz#d7c2bbfe54a0acdca0e90da0c46100a22bf611e3"
+  integrity sha512-N+I0Iho/m1c63+g3E7ZgfGnxGZIRAoj9TUU7j8NFCt+RowqpTLQanLdcfzrCyiHtdEI2MKF1vLMgdyE5rETSnw==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -1143,6 +1148,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+command-exists@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1390,6 +1400,13 @@ expect@^29.0.0, expect@^29.6.4:
     jest-message-util "^29.6.3"
     jest-util "^29.6.3"
 
+external-sorting@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/external-sorting/-/external-sorting-1.3.1.tgz#caec567906bd8d936cc94165c7daf657cd4e3163"
+  integrity sha512-eqI/TxUu4U5RW90ml7bRyvk/0Qh/Lf3JecZQKeLmC0eVRzPQ2UG3ZR7k66EDO1UnTJat0D8bn129K+gnZYMJuw==
+  dependencies:
+    fast-sort "^2.0.1"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1415,6 +1432,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-sort@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fast-sort/-/fast-sort-2.2.0.tgz#20903763531fbcbb41c9df5ab1bf5f2cefc8476a"
+  integrity sha512-W7zqnn2zsYoQA87FKmYtgOsbJohOrh7XrtZrCVHN5XZKqTBTv5UG+rSS3+iWbg/nepRQUOu+wnas8BwtK8kiCg==
 
 fastq@^1.6.0:
   version "1.15.0"


### PR DESCRIPTION
Relying on GNU sort if available I think is good, but running e.g. jbrowse desktop and indexing a track in-app may not have GNU sort, so this adds a backup to use the pure-js implementation of external-sorting